### PR TITLE
Updates corfu/pom.xml to fix compilation errors

### DIFF
--- a/corfu/pom.xml
+++ b/corfu/pom.xml
@@ -18,15 +18,11 @@
   <dependencies>
     <dependency>
       <groupId>org.corfudb</groupId>
-      <artifactId>corfu</artifactId>
-      <version>0.1-SNAPSHOT</version>
-      <type>pom</type>
-    </dependency>
-    <dependency>
-      <groupId>org.corfudb</groupId>
       <artifactId>runtime</artifactId>
       <version>0.1-SNAPSHOT</version>
+      <scope>compile</scope>
     </dependency>
+
     <dependency>
       <groupId>com.yahoo.ycsb</groupId>
       <artifactId>core</artifactId>
@@ -34,6 +30,7 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -58,4 +55,15 @@
       </plugin>
     </plugins>
   </build>
+
+  <repositories>
+    <repository>
+      <id>corfu-mvn-repo</id>
+      <url>https://raw.github.com/CorfuDB/Corfu-Repos/mvn-repo/</url>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
This commit adds the corfu-mvn-repo and updates the dependencies in
corfu/pom.xml.

This was done as instructed in the CorfuDB README.md as of d8c49b82.

The compilation error was the following:

```
[ERROR] Failed to execute goal on project corfu-binding: Could not
resolve dependencies for project
com.yahoo.ycsb:corfu-binding:jar:0.13.0-SNAPSHOT: The following
artifacts could not be resolved: org.corfudb:corfu:pom:0.1-SNAPSHOT,
org.corfudb:runtime:jar:0.1-SNAPSHOT: Could not find artifact
org.corfudb:corfu:pom:0.1-SNAPSHOT -> [Help 1]
```

Addresses [#980](https://github.com/CorfuDB/CorfuDB/issues/980)